### PR TITLE
Gulp is not required as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "Balsamiq Docs Site.",
   "main": "gulpfile.js",
-  "dependencies": {
-    "gulp": "^3.9.0"
-  },
   "devDependencies": {
     "del": "^1.2.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
It is required as devDependency though. The change also addresses a vulnerability in the dependencies of gulp